### PR TITLE
Add redis-database to store datapoints of mks-resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/MiniTeks/mks-server
 go 1.17
 
 require (
+	github.com/go-redis/redis v6.15.8+incompatible
 	github.com/tektoncd/pipeline v0.32.1
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3
@@ -22,7 +23,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
-	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful v2.15.0+incompatible // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,9 @@ github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
+github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charithe/durationcheck v0.0.9/go.mod h1:SSbRIBVfMjCi/kEB6K65XEA83D6prSM8ap1UCpNKtgg=
 github.com/chavacava/garif v0.0.0-20210405164556-e8a0a408d6af/go.mod h1:Qjyv4H3//PWVzTeCezG2b9IRn6myJxJSr4TD/xo6ojU=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
@@ -466,6 +467,7 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-openapi/swag v0.19.15 h1:D2NRCBzS9/pEY3gP9Nl8aDqGUcPFrwG2p+CNFrLyrCM=
 github.com/go-openapi/swag v0.19.15/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-redis/redis v6.15.8+incompatible h1:BKZuG6mCnRj5AOaWJXoCgf6rqTYnYJLe4en2hxT7r9o=
 github.com/go-redis/redis v6.15.8+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=

--- a/k8s/db-deployment.yaml
+++ b/k8s/db-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mks-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mks-db
+  template:
+    metadata:
+      labels:
+        app: mks-db
+    spec:
+      containers:
+      - name: redis
+        image: redis
+        imagePullPolicy: IfNotPresent
+        args: ["--requirepass", "$(REDIS_PASS)"]
+        env:
+          - name: MASTER
+            value: "true"
+          - name: REDIS_PASS
+            valueFrom:
+              secretKeyRef:
+                name: db-secret
+                key: redis-pass
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 6379
+          name: redis
+        volumeMounts:
+          - mountPath: /data
+            name: redis-data
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: redis-data
+
+--- 
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-data
+spec:
+  resources:
+    requests:
+      storage: 100Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/k8s/db-secret.yaml
+++ b/k8s/db-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-secret
+type: Opaque
+data:
+  redis-pass: MTIzNDU=

--- a/k8s/db-service.yaml
+++ b/k8s/db-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mks-db
+spec:
+  selector:
+    app: mks-db
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: 6379
+status:
+  loadBalancer: {}

--- a/pkg/db/client-type.go
+++ b/pkg/db/client-type.go
@@ -1,0 +1,7 @@
+package db
+
+type RClient struct {
+	Addr string
+	Pass string
+	Db   int
+}

--- a/pkg/db/client.go
+++ b/pkg/db/client.go
@@ -1,0 +1,26 @@
+package db
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/go-redis/redis"
+)
+
+func GetRedisClient(cred *RClient) *redis.Client {
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     cred.Addr,
+		Password: cred.Pass, // no password set
+		DB:       cred.Db,   // use default DB 0
+	})
+	keys := []string{"mksTaskcreated", "mksTaskdeleted", "mksTaskactive", "mksTaskfailed", "mksTaskRuncreated", "mksTaskRundeleted", "mksTaskRunactive", "mksTaskRunfailed", "mksPipelineRuncreated", "mksPipelineRundeleted", "mksPipelineRunactive", "mksPipelineRunfailed"}
+	for _, item := range keys {
+		rdb.Set(item, 0, 0)
+	}
+	ping, err := rdb.Ping().Result()
+	if err != nil {
+		log.Fatal("Couldn't connect to redis-database")
+	}
+	fmt.Print(ping, err)
+	return rdb
+}

--- a/pkg/db/handleDbOps.go
+++ b/pkg/db/handleDbOps.go
@@ -1,0 +1,23 @@
+package db
+
+import (
+	"strconv"
+
+	"github.com/go-redis/redis"
+)
+
+func Check(rClient *redis.Client, key string) error {
+	_, err := rClient.Get(key).Result()
+	return err
+}
+
+func Increment(rClient *redis.Client, key string) {
+	rClient.Incr(key)
+}
+func Decrement(rClient *redis.Client, key string) {
+	val, _ := rClient.Get(key).Result()
+	v, _ := strconv.Atoi(val)
+	if int(v) > 0 {
+		rClient.Decr(key)
+	}
+}


### PR DESCRIPTION
## Add redis-database to store and access mks-resources datapoints.

* database configurations in the mks-server
*  redis-client available to controllers
* kubernetes resources to access redis-db

#### How to test
1. Deploy redis-db-server - 
```bash
kubectl apply -f k8s/
```
2.
 ```bash
kubectl port-forward <your redis-db pod, e.g-mks-db-6f544776bf-lsp2r > 6379:6379
```
3. Build and execute (see README.md) 

#### Next steps 
1. Add a new argument - redisClient to your respective NewController().
2. Bind methods to the handlers to store data-points
3. Add the redisClient configs in controllers instances in main.go

Fixes #20 