### PR TITLE
Add redis functions to MksTaskRun controller

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	informers := informers.NewSharedInformerFactory(mksClient, 10*time.Minute)
 	mprc := mprcontroller.NewController(kubeClient, mksClient, informers.Mkscontroller().V1alpha1().MksPipelineRuns())
 	mtc := mtcontroller.NewController(*mksClient, informers.Mkscontroller().V1alpha1().MksTasks(), redisClient)
-	mtrc := mtrcontroller.NewController(kubeClient, mksClient, informers.Mkscontroller().V1alpha1().MksTaskRuns())
+	mtrc := mtrcontroller.NewController(kubeClient, mksClient, informers.Mkscontroller().V1alpha1().MksTaskRuns(), redisClient)
 
 	informers.Start(ch)
 

--- a/pkg/controllers/mkstaskrun/controller.go
+++ b/pkg/controllers/mkstaskrun/controller.go
@@ -7,13 +7,17 @@ import (
 	"github.com/MiniTeks/mks-server/pkg/apis/mkscontroller/v1alpha1"
 	clientset "github.com/MiniTeks/mks-server/pkg/client/clientset/versioned"
 	informer "github.com/MiniTeks/mks-server/pkg/client/informers/externalversions/mkscontroller/v1alpha1"
+	"github.com/MiniTeks/mks-server/pkg/db"
 	"github.com/MiniTeks/mks-server/pkg/tconfig"
+	"github.com/go-redis/redis/v8"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
+
+var rClient *redis.Client
 
 type Controller struct {
 	kubeclientset  kubernetes.Interface
@@ -24,7 +28,8 @@ type Controller struct {
 
 func NewController(kubeclientset kubernetes.Interface,
 	mksclientset clientset.Interface,
-	mksinformer informer.MksTaskRunInformer) *Controller {
+	mksinformer informer.MksTaskRunInformer, redisClient *redis.Client) *Controller {
+	rClient = redisClient
 	controller := &Controller{
 		kubeclientset:  kubeclientset,
 		mksclientset:   mksclientset,
@@ -33,46 +38,45 @@ func NewController(kubeclientset kubernetes.Interface,
 	}
 
 	mksinformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    addController,
-		UpdateFunc: updateController,
-		DeleteFunc: deleteController,
+		AddFunc:    controller.addController,
+		UpdateFunc: controller.updateController,
+		DeleteFunc: controller.deleteController,
 	})
 
 	return controller
 }
 
-func addController(obj interface{}) {
+func (c *Controller) addController(obj interface{}) {
 	fmt.Println("MksTaskRun has been created")
 
 	tp := &tconfig.TektonParam{}
 	tcl, err := tp.Client()
 	if err != nil {
 		fmt.Errorf("Cannot connect to Tekton client: %w", err)
+		return
 	}
 	ttr, err := Create(tcl, obj.(*v1alpha1.MksTaskRun), metav1.CreateOptions{}, "default")
 	if err != nil {
+		db.Increment(rClient, "mksTaskRunfailed")
 		fmt.Errorf("Cannot create Tekton TaskRun: %w", err)
+		return
+	} else {
+		db.Increment(rClient, "mksTaskRuncreated")
 	}
 
 	fmt.Printf("Successfully created Tekton TaskRun: %s\n", ttr.Name)
+	c.queue.Add(obj)
 }
 
-func updateController(oldObj, newObj interface{}) {
+func (c *Controller) updateController(oldObj, newObj interface{}) {
 	fmt.Println("MksTaskRun has been updated")
 }
 
-func deleteController(obj interface{}) {
+func (c *Controller) deleteController(obj interface{}) {
 	fmt.Println("MksTaskRun has been deleted")
+	db.Increment(rClient, "mksTaskRundeleted")
+	c.queue.Add(obj)
 }
-
-// func (c *Controller) Run(stopC <-chan struct{}) error {
-// 	defer runtime.HandleCrash()
-// 	fmt.Println("Starting MksTaskRun Controller")
-
-// 	<-stopC
-// 	fmt.Println("Shutting down")
-// 	return nil
-// }
 
 func (c *Controller) Run(ch <-chan struct{}) {
 	fmt.Println("starting controller")


### PR DESCRIPTION
# What is changed?
- add redis functions to mkstaskrun
- fixes #25

# How to test
- Deploy redis-db-server -
```
kubectl apply -f k8s/

kubectl port-forward <your redis-db pod, e.g-mks-db-6f544776bf-lsp2r > 6379:6379
```
- Build and execute (see README.md)
