### PR TITLE
Add DB functions for mkspipelinerun

### DIFF
--- a/config/mksResourceExample/mkspipelinerun-eg.yaml
+++ b/config/mksResourceExample/mkspipelinerun-eg.yaml
@@ -1,7 +1,7 @@
 apiVersion: mkscontroller.example.mks/v1alpha1
 kind: MksPipelineRun
 metadata:
-  name: test-pipelinerun
+  name: test-pipelinerun2
 spec:
   pipelineRef:
     name: hello

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/MiniTeks/mks-server
 go 1.17
 
 require (
+	github.com/go-redis/redis v6.15.8+incompatible
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/tektoncd/pipeline v0.32.1
 	k8s.io/api v0.23.3

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 	// sync in memory cache with kubernetes cluster state in every 10 min
 	ch := make(chan struct{})
 	informers := informers.NewSharedInformerFactory(mksClient, 10*time.Minute)
-	mprc := mprcontroller.NewController(kubeClient, mksClient, informers.Mkscontroller().V1alpha1().MksPipelineRuns())
+	mprc := mprcontroller.NewController(kubeClient, mksClient, informers.Mkscontroller().V1alpha1().MksPipelineRuns(), redisClient)
 	mtc := mtcontroller.NewController(*mksClient, informers.Mkscontroller().V1alpha1().MksTasks(), redisClient)
 	mtrc := mtrcontroller.NewController(kubeClient, mksClient, informers.Mkscontroller().V1alpha1().MksTaskRuns())
 

--- a/pkg/controllers/mkspipelinerun/controller.go
+++ b/pkg/controllers/mkspipelinerun/controller.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
+	"github.com/go-redis/redis/v8"
 )
 
 type controller struct {
@@ -19,8 +21,11 @@ type controller struct {
 	mksPipelineCacheSynced cache.InformerSynced
 }
 
+var rClient *redis.Client
+
 // Creates a new controller and returns
-func NewController(kubectlst kubernetes.Interface, clientset clientset.Interface, mksPipelineRunInformer appsinformers.MksPipelineRunInformer) *controller {
+func NewController(kubectlst kubernetes.Interface, clientset clientset.Interface, mksPipelineRunInformer appsinformers.MksPipelineRunInformer, redisClient *redis.Client) *controller {
+	rClient = redisClient
 	c := &controller{
 		mksclientset:           clientset,
 		kubeclientset:          kubectlst,


### PR DESCRIPTION
### What is changed?

- Add redis db functions for mkspipelinerun

### How to test?

- Deploy redis-db-server -
```bash
kubectl apply -f k8s/

kubectl port-forward <your redis-db pod, e.g-mks-db-6f544776bf-lsp2r > 6379:6379
```

- Build and execute (see README.md)

### Related Issues

Fixes #27 